### PR TITLE
fix: Handle reactivated jobs

### DIFF
--- a/views/default.phtml
+++ b/views/default.phtml
@@ -23,7 +23,10 @@ $siProxy = new class () { public function get($k, $v = null) { return $v; }};
     /** @var JobMetaData $meta */
     $meta = JobMetaData::fromJob($job);
     $extraData = $siExists ? SIData::fromJob($job) : $siProxy;?>
-    <?php if ($job->isActive() && $meta->mustProcess()):?>
+    <?php if ($job->isActive() && $meta->mustProcess()):
+        if ($meta->isOffline()):
+            $meta=$meta->withStatus(JobMetaData::STATUS_NEW, 'Reactiveated.');
+          endif;?>
     <JobPositionPosting>
         <JobPositionPostingId><?=JobId::toAaId($job->getId(), $partnerNr)?></JobPositionPostingId>
         <HiringOrg>
@@ -156,9 +159,6 @@ $siProxy = new class () { public function get($k, $v = null) { return $v; }};
         </JobPositionInformation>
     </JobPositionPosting>
     <?php
-          if ($meta->isOffline()):
-            $meta=$meta->withStatus(JobMetaData::STATUS_NEW, 'Reactiveated.');
-          endif;
           $meta->commit()->storeIn($job); $this->processed->count++;else:?>
     <?php if (!$meta->isNew() && !$meta->isOffline() && $meta->mustProcess()):
         $ItemsToDelete[] = JobId::toAaId($job->getId(), $partnerNr);

--- a/views/default.phtml
+++ b/views/default.phtml
@@ -155,7 +155,11 @@ $siProxy = new class () { public function get($k, $v = null) { return $v; }};
             <AssignmentStartDate><?=$extraData->get('AssignmentStartDate') ?? date('Y-m-d', time() + 24*60*60)?></AssignmentStartDate>
         </JobPositionInformation>
     </JobPositionPosting>
-    <?php $meta->commit()->storeIn($job); $this->processed->count++;else:?>
+    <?php
+          if ($meta->isOffline()):
+            $meta=$meta->withStatus(JobMetaData::STATUS_NEW, 'Reactiveated.');
+          endif;
+          $meta->commit()->storeIn($job); $this->processed->count++;else:?>
     <?php if (!$meta->isNew() && !$meta->isOffline() && $meta->mustProcess()):
         $ItemsToDelete[] = JobId::toAaId($job->getId(), $partnerNr);
         $meta->withStatus(JobMetaData::STATUS_OFFLINE, 'Job is expired.')->commit()->storeIn($job);


### PR DESCRIPTION
If a job was reactivated (after deleted from the BA), a delete request was send rather than a insert request.

